### PR TITLE
Customizable Rubocop severities

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,10 @@ Pronto runner for [Rubocop](https://github.com/bbatsov/rubocop), ruby code analy
 
 Configuring Rubocop via .rubocop.yml will work just fine with pronto-rubocop.
 You can also specify a custom `.rubocop.yml` location with the environment variable `RUBOCOP_CONFIG`
+
+You can also provide additional configuration via `.pronto.yml`:
+     rubocop:
+      # Map of Rubocop severity level to Pronto severity level
+      severities:
+        refactor: info
+        warning: error

--- a/lib/pronto/rubocop.rb
+++ b/lib/pronto/rubocop.rb
@@ -8,6 +8,7 @@ module Pronto
 
       @config_store = ::RuboCop::ConfigStore.new
       @config_store.options_config = ENV['RUBOCOP_CONFIG'] if ENV['RUBOCOP_CONFIG']
+      @runner_config = Pronto::ConfigFile.new.to_h['rubocop'] || {}
       @inspector = ::RuboCop::Runner.new({}, @config_store)
     end
 
@@ -60,12 +61,17 @@ module Pronto
     end
 
     def level(severity)
-      case severity
-      when :refactor, :convention
-        :warning
-      when :warning, :error, :fatal
-        severity
-      end
+      default_severities = {
+        refactor: :warning,
+        convention: :warning,
+        warning: :warning,
+        error: :error,
+        fatal: :fatal
+      }
+      severities = @runner_config['severities'] || {}
+      severities = Hash[severities.map { |k, v| [k.to_sym, v.to_sym] }]
+
+      default_severities.merge(severities)[severity]
     end
   end
 end

--- a/spec/pronto/rubocop_spec.rb
+++ b/spec/pronto/rubocop_spec.rb
@@ -27,6 +27,23 @@ module Pronto
           it { should_not be_nil }
         end
       end
+
+      context 'when severity is customized' do
+        let(:rubocop_customization) { {} }
+        let(:severity) { :warning }
+
+        before { rubocop.instance_variable_set(:@runner_config, rubocop_customization) }
+
+        context 'when not specified' do
+          it { should eq :warning }
+        end
+
+        context 'when overriden' do
+          let(:rubocop_customization) { { 'severities' => { 'warning' => 'info' } } }
+
+          it { should eq :info }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Add ability to customize Rubocop=>Pronto severities, previously all of them were "critical" and resulted in exit codes != 0